### PR TITLE
kie-issues#58-Add boolean logic examples to the DMN FEEL handbook #58

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -439,6 +439,26 @@ You can use the `every` to check if all the elements satisfies specific conditio
 
 You can use the `in expression` to check if a given value is matched by a specified range.
 
+## boolean expression(and, or)
+
+> Examples
+
+```FEEL,commented
+true and true   //➔ true
+true and false and null   //➔ false
+true and null and true   //➔ null
+true or false or null   //➔ true
+false or false   //➔ false
+false or null or false  //➔ null
+true or false and false   //➔ true
+(true or false) and false   //➔ false
+```
+You can use `and` and `or expressions` as the classic and (&&), and or (||) operators in other languages, with the addition that the result can evaluate to null.
+
+<aside class="warning">
+Please notice that <code>and</code> is evaluated before <code>or</code>.
+</aside>
+
 # String functions
 
 This chapter explores the DMN FEEL specification built-in functions for `string`s.

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -439,7 +439,7 @@ You can use the `every` to check if all the elements satisfies specific conditio
 
 You can use the `in expression` to check if a given value is matched by a specified range.
 
-## boolean expression(and, or)
+## Three-valued logic(and, or)
 
 > Examples
 
@@ -453,7 +453,8 @@ false or null or false  //➔ null
 true or false and false   //➔ true
 (true or false) and false   //➔ false
 ```
-You can use `and` and `or expressions` as the classic and (&&), and or (||) operators in other languages, with the addition that the result can evaluate to null.
+
+FEEL supports three-valued logic (3VL) semantic. You can use `and` and `or` as the classic and (`&&`), and or (`||`) boolean operators in other languages, with the addition that the result can evaluate to null.
 
 <aside class="warning">
 Please notice that <code>and</code> is evaluated before <code>or</code>.

--- a/test.java
+++ b/test.java
@@ -1,6 +1,6 @@
 ///usr/bin/env jbang "$0" "$@" ; exit $?
 //JAVA 11+
-//DEPS org.kie:kie-dmn-feel:7.73.0.Final
+//DEPS org.kie:kie-dmn-feel:8.31.0.Final
 //DEPS org.slf4j:slf4j-simple:1.7.36
 //DEPS info.picocli:picocli:4.6.3
 //DEPS com.vladsch.flexmark:flexmark-all:0.64.0


### PR DESCRIPTION
Closses https://github.com/kiegroup/kie-issues/issues/58

Created new section about boolean expressions to the DMN FEEL handbook.
Added examples of how to use 'and' and 'or' boolean operators with FEEL values that clarify what evaluates to true, false or null