### PR TITLE
ci: fix build.yml rubygems-update version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
 
     # necessary to get ruby 2.3 to work nicely with bundler vendor/bundle cache
     # can remove once ruby 2.3 is no longer supported
-    - run: gem update --system
+    - run: gem update --system 3.4.22
 
     - run: bundle config set deployment 'true'
     - name: bundle install


### PR DESCRIPTION
At the time of writing, the latest rubygems-update require ruby >= 3.0.0

Error message reported for build.yml on GHA ci:
```
Run gem update --system
ERROR:  Error installing rubygems-update:
	There are no versions of rubygems-update (= 3.5.4) compatible with your Ruby & RubyGems
	rubygems-update requires Ruby version >= 3.0.0. The current ruby version is 2.7.8.225.
```

For example: https://github.com/kiegroup/dmn-feel-handbook/actions/runs/7473884877/job/20338928937

This happens when `ruby-version` from matrix is 2.7

At the time of this change, the latest rubygems-update compatible with ruby 2.7 is: 3.4.22

Pinning rubygems-update to 3.4.22 for the GHA ci scope