### PR TITLE
Add new job to testing PR check that tests with latest SNAPSHOT version of Drools

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,9 +7,9 @@ on:
     branches: [ '*' ]
 
 jobs:
-  jbang:
+  jbang-drools-stable:
     runs-on: ubuntu-latest
-    name: Testing FEEL expressions in the MarkDown with JBang
+    name: Testing FEEL expressions in the MarkDown with JBang with Drools latest stable release
     steps:
     - name: checkout
       uses: actions/checkout@v1
@@ -23,3 +23,21 @@ jobs:
       uses: jbangdev/jbang-action@v0.111.0
       with:
         script: test.java
+  jbang-drools-snapshot:
+    runs-on: ubuntu-latest
+    name: Testing FEEL expressions in the MarkDown with JBang with Drools latest SNAPSHOT release
+    steps:
+      - name: checkout
+        uses: actions/checkout@v1
+      - uses: actions/cache@v1
+        with:
+          path: /root/.jbang
+          key: $-jbang-$
+          restore-keys: |
+            $-jbang-
+      - name: jbang
+        uses: jbangdev/jbang-action@v0.111.0
+        with:
+          script: test.java
+        env:
+          drools_version: 999-SNAPSHOT

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   jbang-drools-stable:
     runs-on: ubuntu-latest
-    name: Testing FEEL expressions in the MarkDown with JBang with Drools latest stable release
+    name: Testing with Drools latest stable release
     steps:
     - name: checkout
       uses: actions/checkout@v1
@@ -25,7 +25,7 @@ jobs:
         script: test.java
   jbang-drools-snapshot:
     runs-on: ubuntu-latest
-    name: Testing FEEL expressions in the MarkDown with JBang with Drools latest SNAPSHOT release
+    name: Testing with Drools latest SNAPSHOT release
     steps:
       - name: checkout
         uses: actions/checkout@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,5 +39,4 @@ jobs:
         uses: jbangdev/jbang-action@v0.111.0
         with:
           script: test.java
-        env:
-          drools_version: 999-SNAPSHOT
+          jbangargs: -Ddrools.version=999-SNAPSHOT

--- a/test.java
+++ b/test.java
@@ -1,5 +1,5 @@
 ///usr/bin/env jbang "$0" "$@" ; exit $?
-//JAVA 11+
+//JAVA 17+
 //REPOS mavencentral,apache=https://repository.apache.org/content/groups/public/
 //DEPS org.kie:kie-dmn-feel:${drools.version:9.44.0.Final}
 //DEPS org.slf4j:slf4j-simple:1.7.36

--- a/test.java
+++ b/test.java
@@ -82,8 +82,13 @@ public class test {
         if (usedVersion.equals(latestVersion)) {
             System.out.println(CommandLine.Help.Ansi.AUTO.string("@|bold,green OK|@"));
         } else {
-            System.out.println(CommandLine.Help.Ansi.AUTO.string("@|bold,red FAIL|@"));
-            System.exit(-1);
+            if (usedVersion.endsWith("-SNAPSHOT")) {
+                System.out.println(CommandLine.Help.Ansi.AUTO.string("@|bold,green OK|@"));
+                System.out.println("Using a SNAPSHOT version, the previous version check was automatically marked as OK. ");
+            } else {
+                System.out.println(CommandLine.Help.Ansi.AUTO.string("@|bold,red FAIL|@"));
+                System.exit(-1);
+            }
         }
     }
 

--- a/test.java
+++ b/test.java
@@ -1,5 +1,6 @@
 ///usr/bin/env jbang "$0" "$@" ; exit $?
 //JAVA 11+
+//REPOS mavencentral,apache=https://repository.apache.org/content/groups/public/
 //DEPS org.kie:kie-dmn-feel:${drools.version:9.44.0.Final}
 //DEPS org.slf4j:slf4j-simple:1.7.36
 //DEPS info.picocli:picocli:4.7.5

--- a/test.java
+++ b/test.java
@@ -1,6 +1,6 @@
 ///usr/bin/env jbang "$0" "$@" ; exit $?
 //JAVA 11+
-//DEPS org.kie:kie-dmn-feel:${drools_version:9.44.0.Final}
+//DEPS org.kie:kie-dmn-feel:${drools.version:9.44.0.Final}
 //DEPS org.slf4j:slf4j-simple:1.7.36
 //DEPS info.picocli:picocli:4.7.5
 //DEPS com.vladsch.flexmark:flexmark-all:0.64.8

--- a/test.java
+++ b/test.java
@@ -1,6 +1,6 @@
 ///usr/bin/env jbang "$0" "$@" ; exit $?
 //JAVA 11+
-//DEPS org.kie:kie-dmn-feel:9.44.0.Final
+//DEPS org.kie:kie-dmn-feel:${drools_version:9.44.0.Final}
 //DEPS org.slf4j:slf4j-simple:1.7.36
 //DEPS info.picocli:picocli:4.7.5
 //DEPS com.vladsch.flexmark:flexmark-all:0.64.8
@@ -128,29 +128,29 @@ public class test {
             if (o1 == null || o2 == null) {
                 return o1 == null ? o2 == null ? 0 : -1 : 1;
             }
-    
+
             String[] split1 = o1.split("\\.");
             String[] split2 = o2.split("\\.");
             int length = Math.min(split1.length, split2.length);
-    
+
             for (int i = 0; i < length; i++) {
                 char c1 = split1[i].charAt(0);
                 char c2 = split2[i].charAt(0);
                 int cmp = 0;
-    
+
                 if (c1 >= '0' && c1 <= '9' && c2 >= '0' && c2 <= '9') {
                     cmp = new BigInteger(split1[i]).compareTo(new BigInteger(split2[i]));
                 }
-    
+
                 if (cmp == 0) {
                     cmp = split1[i].compareTo(split2[i]);
                 }
-    
+
                 if (cmp != 0) {
                     return cmp;
                 }
             }
-    
+
             return split1.length - split2.length;
         }
     }


### PR DESCRIPTION
Hi, sometimes, there may be new FEEL functionality added in the Drools engine, e.g. as part of implementing new DMN versions. This new functionality may not yet be available in a stable Drools version and it may only be in the SNAPSHOT versions released. With this, writing new documentation may be not possible, because there is no way, how to test new FEEL expressions added, that depend on functionality in the SNAPSHOTS. 

This PR adds another job to the test workflow, which runs all the expressions against the SNAPSHOT version of Drools. There are two PR checks scenarios then (apart of scenarios due to failing expressions because they are written incorrectly): 
- New chapters/FEEL expressions added, that rely on SNAPSHOTs: 
  - This shows up as a failure on the Drools stable test job and shows the SNAPSHOT test job green. 
- Changes done using the existing Drools DMN functionality:
  - Both jobs are green. 
 
@tarilabs what do you think about this please? Would it be fine, to add another job to the PR checks please? 
