### PR TITLE
Fix typo month -> week

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -1966,7 +1966,7 @@ Returns the Gregorian month of the year: `"January"`, `"February"`,
 `"March"`, `"April"`, `"May"`, `"June"`, `"July"`, `"August"`,
 `"September"`, `"October"`, `"November"`, or `"December"`.
 
-## month of year( date )
+## week of year( date )
 
 | Parameter          | Type                                            |
 |-|-|


### PR DESCRIPTION
Not much more to it. Seems to be a copy & paste / typo issue.